### PR TITLE
Use Path instead of &str for file path

### DIFF
--- a/python/regex_money/main.py
+++ b/python/regex_money/main.py
@@ -1,6 +1,7 @@
 import json
 import re
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 # Compiled patterns
@@ -9,7 +10,7 @@ hyphenated_pattern = re.compile(r"\$(\d+\.?\d*)([KMB])?-?\$?(\d+\.?\d*)([KMB])?"
 
 def get_data() -> dict[str, Any]:
     data = {}
-    with open("data/companies.json", "r") as f:
+    with open(Path("data/companies.json"), "r") as f:
         data = json.load(f)
     return data
 

--- a/rust/regex_money/src/main.rs
+++ b/rust/regex_money/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -20,9 +22,11 @@ struct CompanyFinal {
     annual_revenue_upper: f64,
 }
 
-fn get_data(path: &str) -> Vec<Company> {
-    let file_path = path.to_owned();
-    let contents = fs::read_to_string(file_path).expect("Could not load from file");
+fn get_data(path: &Path) -> Vec<Company> {
+    if !path.exists() {
+        panic!("File {:?} not found", path);
+    }
+    let contents = fs::read_to_string(path).expect("Could not load from file");
     let data: Vec<Company> = serde_json::from_str(&contents).unwrap();
     data
 }
@@ -66,7 +70,7 @@ fn construct_company_final(
 }
 
 fn run() -> Vec<CompanyFinal> {
-    let data: Vec<Company> = get_data("data/companies.json");
+    let data: Vec<Company> = get_data(Path::new("data/companies.json"));
     let mut companies: Vec<CompanyFinal> = Vec::new();
     for company in data {
         let (annual_revenue_lower, annual_revenue_upper) = calculate_range(&company.annual_revenue);


### PR DESCRIPTION
You may have a reason for using `&str` here so this is just a suggestion. This change is basically the equivalent of using `Path` in Python.