### PR TITLE
Add persons.csv file

### DIFF
--- a/rust/postgres_etl/data/persons.csv
+++ b/rust/postgres_etl/data/persons.csv
@@ -1,0 +1,11 @@
+id,name,age,isMarried,city,state,country
+1,Megan Chang,48,false,Fredonia,Antioquia,Colombia
+2,Billy Sheppard,38,false,Campeche,Campeche,Mexico
+3,Richard Bowers,53,false,Tahannawt,Marrakech-Safi,Morocco
+4,Tammy Howard,41,true,Somandepalle,Andhra Pradesh,India
+5,William Campbell,44,true,Dimiao,Bohol,Philippines
+6,Christine King,35,true,Kanur,Karnataka,India
+7,Kyle Blair,30,false,Ettapur,Tamil Nadu,India
+8,Thomas Garcia,30,false,Gurpinar,Van,Turkey
+9,Leslie Bowman,61,true,Madaba,Madaba,Jordan
+10,Tammy Woods,56,false,Vernon,British Columbia,Canada


### PR DESCRIPTION
The rust postgres_etl tries to load data from `data/persons.csv`, but this file is missing from the rust example. I copied the file in the python directory into here.