### PR TITLE
Create persons table at startup

### DIFF
--- a/rust/postgres_etl/sql/create_persons_table.sql
+++ b/rust/postgres_etl/sql/create_persons_table.sql
@@ -1,9 +1,0 @@
-CREATE TABLE IF NOT EXISTS persons(
-    id integer PRIMARY KEY,
-    name text,
-    age smallint,
-    isMarried boolean,
-    city text,
-    state text,
-    country text
-)

--- a/rust/postgres_etl/sql/init.sql
+++ b/rust/postgres_etl/sql/init.sql
@@ -1,2 +1,14 @@
 SELECT 'CREATE DATABASE etl'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'etl')\gexec
+
+\connect etl
+
+CREATE TABLE IF NOT EXISTS persons(
+    id integer PRIMARY KEY,
+    name text,
+    age smallint,
+    isMarried boolean,
+    city text,
+    state text,
+    country text
+)\gexec


### PR DESCRIPTION
Closes #7

From what I can tell [here](https://github.com/launchbadge/sqlx?tab=readme-ov-file#compile-time-verification) in order to use the `query!` macro the table has to be present in the database. Did you delete the `data/pg` directory when you started clean? When removing volumes the tables seem to stay around for me unless I delete that directory. That is the only way I could explain the differences we are seeing.

Moving the creation of the table to the `init.sql` fixes the problem on my end.