### PR TITLE
Use connection pools

### DIFF
--- a/python/postgres_etl/load_data.py
+++ b/python/postgres_etl/load_data.py
@@ -50,7 +50,7 @@ async def run() -> int:
 
     # Insert data
     tasks = []
-    async with asyncpg.create_pool(PG_URI) as pool:
+    async with asyncpg.create_pool(PG_URI, min_size=5, max_size=5) as pool:
         for person in persons:
             tasks.append(insert(pool, person))
 

--- a/python/postgres_etl/load_data.py
+++ b/python/postgres_etl/load_data.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import asyncpg
-from asyncpg.connection import Connection
+from asyncpg.pool import Pool
 from dotenv import load_dotenv
 
 
@@ -22,8 +22,8 @@ def read_data(filename: Path) -> list[dict[str, Any]] | None:
     return data
 
 
-async def insert(conn: Connection, persons: list[dict[str, Any]]) -> None:
-    for counter, person in enumerate(persons, 1):
+async def insert(pool: Pool, person: dict[str, Any]) -> None:
+    async with pool.acquire() as conn:
         await conn.execute(
             """
                 INSERT INTO persons (id, name, age, isMarried, city, state, country)
@@ -37,20 +37,26 @@ async def insert(conn: Connection, persons: list[dict[str, Any]]) -> None:
             person["state"],
             person["country"],
         )
-    return counter
 
 
 async def run() -> int:
     PG_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
     PG_URI = f"postgres://postgres:{PG_PASSWORD}@localhost:5432/etl"
-    conn = await asyncpg.connect(PG_URI)
 
     persons = read_data(Path("data/persons.csv"))
+    if not persons:
+        raise ValueError("No people found")
+    counter = len(persons)
+
     # Insert data
-    counter = await insert(conn, persons)
+    tasks = []
+    async with asyncpg.create_pool(PG_URI) as pool:
+        for person in persons:
+            tasks.append(insert(pool, person))
+
+        await asyncio.gather(*tasks)
     print(f"Finished loading {counter} records")
 
-    await conn.close()
     return counter
 
 

--- a/python/postgres_etl/main.py
+++ b/python/postgres_etl/main.py
@@ -25,7 +25,7 @@ async def main(limit: int) -> None:
     PG_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
     PG_URI = f"postgres://postgres:{PG_PASSWORD}@localhost:5432/etl"
 
-    async with asyncpg.create_pool(PG_URI) as pool:
+    async with asyncpg.create_pool(PG_URI, min_size=5, max_size=5) as pool:
         # Fix seed
         random.seed(1)
         # Test performance

--- a/python/postgres_etl/test_main.py
+++ b/python/postgres_etl/test_main.py
@@ -13,7 +13,7 @@ async def get_pool():
     load_dotenv()
     PG_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
     PG_URI = f"postgres://postgres:{PG_PASSWORD}@localhost:5432/etl"
-    pool = await asyncpg.create_pool(PG_URI)
+    pool = await asyncpg.create_pool(PG_URI, min_size=5, max_size=5)
     yield pool
     await pool.close()
 

--- a/python/postgres_etl/test_main.py
+++ b/python/postgres_etl/test_main.py
@@ -9,23 +9,25 @@ from main import perf_query
 
 
 @pytest.fixture
-async def get_connection():
+async def get_pool():
     load_dotenv()
     PG_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
     PG_URI = f"postgres://postgres:{PG_PASSWORD}@localhost:5432/etl"
-    conn = await asyncpg.connect(PG_URI)
-    yield conn
+    pool = await asyncpg.create_pool(PG_URI)
+    yield pool
+    await pool.close()
 
 
-async def test_summary_query(get_connection):
-    conn = get_connection
-    count = await conn.fetchval("SELECT COUNT(*) AS count FROM persons")
+async def test_summary_query(get_pool):
+    pool = get_pool
+    async with pool.acquire() as conn:
+        count = await conn.fetchval("SELECT COUNT(*) AS count FROM persons")
     assert count > 0
 
 
-async def test_perf_query(get_connection):
-    conn = get_connection
-    age_limits = [random.randint(22, 65) for _ in range(1000)]
+@pytest.mark.parametrize("age_limit", (22, 45))
+async def test_perf_query(age_limit, get_pool):
+    pool = get_pool
     # This is a template test: in a real situation, we'd measure more meaningful counts
-    count = await perf_query(conn, age_limits)
-    assert count == 1000
+    count = await perf_query(pool, age_limit)
+    assert count > 0

--- a/python/postgres_etl/test_main.py
+++ b/python/postgres_etl/test_main.py
@@ -25,9 +25,9 @@ async def test_summary_query(get_pool):
     assert count > 0
 
 
-@pytest.mark.parametrize("age_limit", (22, 45))
-async def test_perf_query(age_limit, get_pool):
+@pytest.mark.parametrize("age_limit, expected", ((22, 10), (65, 0)))
+async def test_perf_query(age_limit, expected, get_pool):
     pool = get_pool
     # This is a template test: in a real situation, we'd measure more meaningful counts
     count = await perf_query(pool, age_limit)
-    assert count > 0
+    assert count == expected

--- a/rust/postgres_etl/src/main.rs
+++ b/rust/postgres_etl/src/main.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use dotenvy::dotenv;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::Serialize;
-use sqlx::{Connection, PgConnection};
+//use sqlx::{Connection, PgConnection};
+use sqlx::PgPool;
 
 mod test_main;
 
@@ -35,20 +38,17 @@ async fn get_age_limits() -> Vec<i16> {
     }
 }
 
-async fn perf_query(mut conn: PgConnection, ages: Vec<i16>) -> Result<i32, sqlx::Error> {
-    let mut count = 0;
-    for age in ages {
-        let query = sqlx::query!(
-            r#"
-            SELECT COUNT(*) AS count
-            FROM persons WHERE age > $1
-            "#,
-            age
-        );
-        _ = query.fetch_one(&mut conn).await?;
-        count += 1;
-    }
-    Ok(count)
+async fn perf_query(pool: Arc<PgPool>, age: i16) -> Result<(), sqlx::Error> {
+    let query = sqlx::query!(
+        r#"
+        SELECT COUNT(*) AS count
+        FROM persons WHERE age > $1
+        "#,
+        age
+    );
+    query.fetch_one(&*pool).await?;
+
+    Ok(())
 }
 
 #[tokio::main]
@@ -56,10 +56,19 @@ async fn main() -> Result<(), sqlx::Error> {
     dotenv().ok();
     // Obtain connection
     let pg_uri = dotenvy::var("DATABASE_URL").unwrap();
-    let conn = PgConnection::connect(&pg_uri).await.unwrap();
+    let pool = Arc::new(PgPool::connect(&pg_uri).await.unwrap());
 
     let ages = get_age_limits().await;
-    let count = perf_query(conn, ages).await.expect("Query did not execute");
-    println!("Number of queries executed: {}", count);
+    let mut tasks = Vec::new();
+
+    for &age in ages.iter() {
+        let task = tokio::spawn(perf_query(Arc::clone(&pool), age));
+        tasks.push(task);
+    }
+    for task in tasks {
+        _ = task.await.expect("Error running task");
+    }
+    pool.close().await;
+    println!("Number of queries executed: {}", ages.len());
     Ok(())
 }

--- a/rust/postgres_etl/src/test_main.rs
+++ b/rust/postgres_etl/src/test_main.rs
@@ -1,16 +1,14 @@
 #![cfg(test)]
 
-use std::sync::Arc;
-
 use dotenvy::dotenv;
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use sqlx::PgPool;
+use sqlx::{PgPool, postgres::PgPoolOptions};
 
 // Get database connection pool for test
 pub async fn get_pool() -> PgPool {
     dotenv().ok();
     let pg_uri = dotenvy::var("DATABASE_URL").expect("Invalid DB URI");
-    let pool = PgPool::connect(&pg_uri)
+    let pool = PgPoolOptions::new().min_connections(5).max_connections(5).connect(&pg_uri)
         .await
         .expect("Could not connect to DB");
     pool
@@ -29,12 +27,12 @@ async fn test_summary_query() {
 
 #[sqlx::test]
 async fn test_perf_query() {
-    let pool = Arc::new(get_pool().await);
+    let pool = get_pool().await;
     let mut rng = StdRng::seed_from_u64(1);
     let ages: Vec<i16> = (0..1000).map(|_| rng.gen_range(22..65)).collect();
     // This is a template test: in a real situation, we'd measure more meaningful counts
     for age in ages {
-        let result = super::perf_query(Arc::clone(&pool), age)
+        let result = super::perf_query(pool.clone(), age)
             .await;
         assert!(result.is_ok());
     }

--- a/rust/postgres_etl/src/test_main.rs
+++ b/rust/postgres_etl/src/test_main.rs
@@ -8,10 +8,9 @@ use sqlx::{PgPool, postgres::PgPoolOptions};
 pub async fn get_pool() -> PgPool {
     dotenv().ok();
     let pg_uri = dotenvy::var("DATABASE_URL").expect("Invalid DB URI");
-    let pool = PgPoolOptions::new().min_connections(5).max_connections(5).connect(&pg_uri)
+    PgPoolOptions::new().min_connections(5).max_connections(5).connect(&pg_uri)
         .await
-        .expect("Could not connect to DB");
-    pool
+        .expect("Could not connect to DB")
 }
 
 #[sqlx::test]


### PR DESCRIPTION
Relates to #6

This is what I came up with for running the queries concurrently. As discussed getting a connection form the pool causes this to be slower than using one connection (this was true in both Python and Rust), but I verified that things are running concurrently this way. 

In something like a web app that is processing multiple requests I would expect to see using pools become the faster option since it would be able to process requests concurrently rather than one at a time.

Feel free to close this if you would rather keep the current, faster in this particular situation, single connection option, or if you came up with a better solution.