### PR TITLE
Updates to Postgres ETL

### DIFF
--- a/python/postgres_etl/load_data.py
+++ b/python/postgres_etl/load_data.py
@@ -22,6 +22,11 @@ def read_data(filename: Path) -> list[dict[str, Any]] | None:
     return data
 
 
+async def truncate_table(pool: Pool) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("TRUNCATE TABLE persons;")
+
+
 async def insert(pool: Pool, person: dict[str, Any]) -> None:
     async with pool.acquire() as conn:
         await conn.execute(
@@ -51,6 +56,9 @@ async def run() -> int:
     # Insert data
     tasks = []
     async with asyncpg.create_pool(PG_URI, min_size=5, max_size=5) as pool:
+        # Truncate persons table before inserting data
+        truncate_table(pool)
+        # Run insert tasks
         for person in persons:
             tasks.append(insert(pool, person))
 


### PR DESCRIPTION
Fixes #14 

This is working PR to address issues with the Postgres ETL.

- `load_data.py` was missing the truncate table command, this has been added.
- Inserting a million records into the table via `asyncpg` is indeed concurrent with the new code, and is *much* faster than before (on my machine finishes in about 2 mins wall-clock time)