### PR TITLE
Add book test

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -22,9 +22,10 @@ jobs:
           mkdir mdbook
           curl -sSL $url | tar -xz --directory=./mdbook
           echo `pwd`/mdbook >> $GITHUB_PATH
-      - name: Build Book
+      - name: Test and build book
         run: |
           cd book
+          mdbook test
           mdbook build
       - name: Setup Pages
         uses: actions/configure-pages@v2

--- a/book/src/pieces/pieces.md
+++ b/book/src/pieces/pieces.md
@@ -6,7 +6,7 @@ A piece is a self-contained project with Python and Rust implementations that ea
 
 A piece's directory structure is organized as follows:
 
-```
+```bash
 pieces
 ├── piece-1
 │   ├── python


### PR DESCRIPTION
Updates the book build workflow to run `mdbook test` prior to building. This helps verify there's no unmarked code blocks and any code blocks marked as `rs` or `rust` will be tested for formatting errors prior to publishing.