### PR TITLE
Postgres ETL changes

### DIFF
--- a/pieces/postgres_etl/README.md
+++ b/pieces/postgres_etl/README.md
@@ -104,9 +104,9 @@ than a random number between 22 and 65. An example query is shown below.
 SELECT COUNT(*) FROM persons WHERE age > 22;
 ```
 
-| numQueries | Python                   | Rust                     |
-| ---------- | ------------------------ | ------------------------ |
-| 100000     | 1 min 27 sec (1149 QPS)  | 0 min 32 sec (3125 QPS)  |
+| numQueries | Python                  | Rust                    |
+| ---------- | ----------------------- | ----------------------- |
+| 100000     | 1 min 27 sec (1149 QPS) | 0 min 32 sec (3125 QPS) |
 
 It can be seen that for 100K such aggregation queries with random age bounds, the Rust code is about
 2.7x faster than the Python code. We will see more on this below.
@@ -154,7 +154,7 @@ order to do this, the Rust code that loads data to the Postgres database is situ
 ```bash
 cargo run --release --bin load_data
 # or
-cargo run --r --bin load_data
+cargo run -r --bin load_data
 ```
 
 #### Run queries
@@ -218,9 +218,9 @@ is greater than a random number between 22 and 65. An example query is shown bel
 SELECT COUNT(*) FROM persons WHERE age > 22;
 ```
 
-| numQueries | Python                   | Rust                     |
-| ---------- | ------------------------ | ------------------------ |
-| 100000     | 1 min 27 sec (1149 QPS)  | 0 min 32 sec (3125 QPS)  |
+| numQueries | Python                  | Rust                    |
+| ---------- | ----------------------- | ----------------------- |
+| 100000     | 1 min 27 sec (1149 QPS) | 0 min 32 sec (3125 QPS) |
 
 It can be seen that for 100K such aggregation queries with random age bounds, the Rust code is about
 2.7x faster than the Python code. Note that the QPS and the run time depend on the CPU, OS, and the

--- a/pieces/postgres_etl/rust/src/main.rs
+++ b/pieces/postgres_etl/rust/src/main.rs
@@ -2,20 +2,45 @@ use dotenvy::dotenv;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::Serialize;
 use sqlx::{postgres::PgPoolOptions, PgPool};
+use std::sync::Arc;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Person {
     id: i32,
     name: String,
-    age: i16,
+    age: i16, // Postgres does not have unsigned integers
     is_married: bool,
     city: String,
     state: String,
     country: String,
 }
 
-async fn get_age_limits() -> Vec<i16> {
+async fn get_pool(pg_uri: &str) -> Result<Arc<PgPool>, sqlx::Error> {
+    let pool = Arc::new(
+        PgPoolOptions::new()
+            .min_connections(20)
+            .max_connections(20)
+            .connect(pg_uri)
+            .await
+            .expect("Cannot obtain connection from pool"),
+    );
+    Ok(pool)
+}
+
+async fn perf_query(pool: Arc<PgPool>, age: i16) -> Result<(), sqlx::Error> {
+    let query = sqlx::query!(
+        r#"
+        SELECT COUNT(*) AS count
+        FROM persons WHERE age > $1
+        "#,
+        age
+    );
+    query.fetch_one(&*pool).await?;
+    Ok(())
+}
+
+async fn get_age_limits() -> Result<Vec<i16>, sqlx::Error> {
     // Generate array of random numbers of length 100, with values between 22 and 65
     let mut rng = StdRng::seed_from_u64(1);
     // Collect args
@@ -24,50 +49,35 @@ async fn get_age_limits() -> Vec<i16> {
         // If no args are provided, length is 1 because the first arg is the program name
         1 => {
             println!("No arguments provided. Defaulting to generating 1000 random age values.");
-            (0..1000).map(|_| rng.gen_range(22..65)).collect()
+            let ages = (0..1000).map(|_| rng.gen_range(22..65)).collect();
+            Ok(ages)
         }
         _ => {
-            let limit: i32 = args[1].parse::<i32>().unwrap();
-            (0..limit).map(|_| rng.gen_range(22..65)).collect()
+            let limit: i32 = args[1].parse::<i32>().expect("Invalid limit provided");
+            let ages = (0..limit).map(|_| rng.gen_range(22..65)).collect();
+            Ok(ages)
         }
     }
-}
-
-async fn perf_query(pool: PgPool, age: i16) -> Result<(), sqlx::Error> {
-    let query = sqlx::query!(
-        r#"
-        SELECT COUNT(*) AS count
-        FROM persons WHERE age > $1
-        "#,
-        age
-    );
-    query.fetch_one(&pool).await?;
-
-    Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), sqlx::Error> {
     dotenv().ok();
     // Obtain connection
-    let pg_uri = dotenvy::var("DATABASE_URL").unwrap();
-    let pool = PgPoolOptions::new()
-        .min_connections(5)
-        .max_connections(5)
-        .connect(&pg_uri)
-        .await?;
-
-    let ages = get_age_limits().await;
+    let pg_uri = dotenvy::var("DATABASE_URL").expect("Invalid DB URI");
+    let pool = get_pool(&pg_uri).await?;
+    let ages = get_age_limits().await?;
     let mut tasks = Vec::new();
 
+    // Create async tasks to query data
     for &age in ages.iter() {
-        let task = tokio::spawn(perf_query(pool.clone(), age));
+        let task = tokio::spawn(perf_query(Arc::clone(&pool), age));
         tasks.push(task);
     }
+    // Run async tasks
     for task in tasks {
-        _ = task.await.expect("Error running task");
+        _ = task.await.expect("Error running async task");
     }
-    pool.close().await;
     println!("Number of queries executed: {}", ages.len());
     Ok(())
 }
@@ -77,22 +87,24 @@ mod tests {
     use super::*;
 
     // Get database connection pool for test
-    pub async fn get_pool() -> PgPool {
+    pub async fn get_pool() -> Arc<PgPool> {
         dotenv().ok();
         let pg_uri = dotenvy::var("DATABASE_URL").expect("Invalid DB URI");
-        PgPoolOptions::new()
-            .min_connections(5)
-            .max_connections(5)
-            .connect(&pg_uri)
-            .await
-            .expect("Could not connect to DB")
+        Arc::new(
+            PgPool::connect(&pg_uri)
+                .await
+                .expect("Could not connect to DB"),
+        )
     }
 
     #[sqlx::test]
     async fn test_summary_query() {
         let pool = get_pool().await;
         let query = sqlx::query!("SELECT COUNT(*) AS count FROM persons");
-        let result = query.fetch_one(&pool).await.expect("Query did not execute");
+        let result = query
+            .fetch_one(&*pool)
+            .await
+            .expect("Query did not execute");
         assert!(result.count.unwrap() > 0);
     }
 


### PR DESCRIPTION
Closes #6.

Changes to the Postgres ETL piece include:
- Fix the number of person records being ingested to the DB as 100K, rather than 1M (for reasons described in #16).
- Switch to using `PgPoolOptions` to control the number of min/max threads - this has an impact on performance (more threads, up to a limit, perform better), so this is an important setting.
- Refactor the Rust functions to be more in line with the Python ones
- Better error handling - using the `?` operator in more places to propagate errors to the calling function now
- Reran data ingestion and async aggregation queries in release mode for Rust. Closes #14.
- Updated the timing numbers in the docs - as expected, the Rust code is significantly faster than the Python code on both counts
- Added the key takeaways in the final section of the README
