### PR TITLE
Collapse level 2 headers in sidebar for book

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -11,3 +11,7 @@ additional-css = ["theme/extra.css"]
 git-repository-url = "https://github.com/thedataquarry/rustinpieces"
 git-repository-icon = "fa-github"
 edit-url-template = "https://github.com/thedataquarry/rustinpieces/edit/main/book/{path}"
+
+[output.html.fold]
+enable = true
+level = 1  # Avoid showing subsections in the sidebar as it becomes overwhelming


### PR DESCRIPTION
Collapsing level  2 headers and beyond in the sidebar as it gets too overwhelming.