### PR TITLE
Fix clippy lints and dead_code warning on Rust 1.96.0

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   database:
-    image: "postgres:latest"
+    image: "postgres:17"
     ports:
       - 5432:5432
     environment:

--- a/src/intro/rust/src/main.rs
+++ b/src/intro/rust/src/main.rs
@@ -114,7 +114,7 @@ fn run6() {
     for person in persons {
         // check if person is born in a leap year using simplistic leap year logic
         let birth_year = approx_year_of_birth(&person);
-        let person_is_born_in_leap_year = birth_year % 4 == 0;
+        let person_is_born_in_leap_year = birth_year.is_multiple_of(4);
         println!("{person}. Born in a leap year?: {person_is_born_in_leap_year}");
     }
     /*

--- a/src/rest_api_postgres/rust/src/db.rs
+++ b/src/rest_api_postgres/rust/src/db.rs
@@ -43,6 +43,7 @@ pub async fn create_pool(pg_uri: &str) -> Result<PgPool> {
     Ok(pool)
 }
 
+#[allow(dead_code)]
 pub fn internal_error<E>(err: E) -> (StatusCode, String)
 where
     E: std::error::Error,


### PR DESCRIPTION
## Summary

CI on `main` has been failing the **Clippy** and **Tests** jobs, blocking open PRs (#151, #152) from merging. This fixes all three underlying causes — two from the Rust 1.96.0 upgrade, one from a drifting `postgres:latest` image.

## Diagnosis & fixes

**1. `clippy::manual_is_multiple_of` (new lint) — breaks the Clippy job**
`src/intro/rust/src/main.rs` used `birth_year % 4 == 0`. Rust 1.96 stabilized `Integer::is_multiple_of`, and Clippy added the `manual_is_multiple_of` lint flagging `% n == 0`. With CI running `clippy -- --deny warnings`, it became a hard error.
→ `birth_year.is_multiple_of(4)`

**2. `dead_code` on `internal_error` — breaks both the Clippy and Tests jobs**
In `src/rest_api_postgres/rust/src/db.rs`, `internal_error` is only referenced inside `DbManager`'s `FromRequestParts` impl, and `DbManager` is an extractor that's never wired into a handler (it already carries `#[allow(dead_code)]`). Rust 1.96's dead-code analysis now propagates "deadness" through such chains, flagging `internal_error`. The workflow's global `RUSTFLAGS: "-D warnings"` promotes it to an error — which is why the Tests job also failed before any test ran.
→ add `#[allow(dead_code)]` to `internal_error`, matching the existing convention on `DbManager`

**3. `postgres:latest` drift — breaks the Tests job (DB connection timeout)**
CI was green through Aug 2025 and first broke at #150 (Nov 11, 2025), right after PostgreSQL 18's release (Sept 30, 2025). The floating `postgres:latest` tag rolled PG17 → PG18, whose Docker image changed its default data directory; the volume mounted at `/var/lib/postgresql/data` no longer backs the live cluster, the container never becomes ready, and test connections time out after 30s.
→ pin `ci/docker-compose.yml` to `postgres:17`

## Verification
- `cargo clippy --all-targets -- --deny warnings` → clean
- `RUSTFLAGS="-D warnings" cargo test --no-run` → builds clean
- `cargo fmt --all -- --check` → OK
- All pure-logic tests pass locally; DB/meilisearch tests verified on CI.

Note: the unrelated `deploy` (mdBook → GitHub Pages) check fails on PRs by design and is not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)